### PR TITLE
fix resource payload upon copy and new version

### DIFF
--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -397,7 +397,7 @@ def copy_resource_files_and_AVUs(src_res_id, dest_res_id):
 
     for n, f in enumerate(files):
         folder, base = os.path.split(f.short_path)  # strips object information.
-        new_resource_file = ResourceFile.create(tgt_res, base, folder=folder if f.reference_file_path else None,
+        new_resource_file = ResourceFile.create(tgt_res, base, folder=folder,
                                                 is_file_reference=True if f.reference_file_path else False)
 
         # if the original file is part of a logical file, then

--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -397,7 +397,7 @@ def copy_resource_files_and_AVUs(src_res_id, dest_res_id):
 
     for n, f in enumerate(files):
         folder, base = os.path.split(f.short_path)  # strips object information.
-        new_resource_file = ResourceFile.create(tgt_res, base, folder=folder,
+        new_resource_file = ResourceFile.create(tgt_res, base, folder=folder if f.reference_file_path else None,
                                                 is_file_reference=True if f.reference_file_path else False)
 
         # if the original file is part of a logical file, then

--- a/hs_core/models.py
+++ b/hs_core/models.py
@@ -2963,7 +2963,7 @@ class ResourceFile(ResourceFileIRODSMixin):
         """
         if test_exists:
             storage = resource.get_irods_storage()
-        locpath = os.path.join(resource.short_id, "data", "contents") + "/"
+        locpath = os.path.join(resource.short_id, "data") + "/"
         relpath = path
         fedpath = resource.resource_federation_path
         if fedpath and relpath.startswith(fedpath + '/'):
@@ -3059,7 +3059,7 @@ class ResourceFile(ResourceFileIRODSMixin):
         from hs_core.views.utils import create_folder
         path_is_allowed(folder)
         # TODO: move code from location used below to here
-        create_folder(resource.short_id, os.path.join('data', 'contents', folder))
+        create_folder(resource.short_id, os.path.join('data', folder))
 
     # TODO: move to BaseResource as instance method
     @classmethod
@@ -3069,7 +3069,7 @@ class ResourceFile(ResourceFileIRODSMixin):
         from hs_core.views.utils import remove_folder
         path_is_allowed(folder)
         # TODO: move code from location used below to here
-        remove_folder(user, resource.short_id, os.path.join('data', 'contents', folder))
+        remove_folder(user, resource.short_id, os.path.join('data', folder))
 
     @property
     def has_logical_file(self):


### PR DESCRIPTION
Hong, I modified the "folder" parameter which was being set incorrectly upon copy or new version for a local resource file.  Basically it needs to be None for a local resource but it needs to be set to the reference file path for a reference file.  Please review. 