### PR TITLE
separated service urls

### DIFF
--- a/globus_data_reg_app/views.py
+++ b/globus_data_reg_app/views.py
@@ -21,10 +21,10 @@ def store(request):
     if path:
         # list file/dir entries for a given globus storage bucket id
         url = '{}registration/list_bucket_path?provider=globus&token={}&bucket_id={}&path={}'.format(
-            settings.SERVICE_SERVER_URL, token, ds_uuid, path)
+            settings.DATA_REG_SERVICE_SERVER_URL, token, ds_uuid, path)
     else:
         # list file/dir entries for a given globus storage bucket id
-        url = '{}registration/list_bucket?provider=globus&token={}&bucket_id={}'.format(settings.SERVICE_SERVER_URL,
+        url = '{}registration/list_bucket?provider=globus&token={}&bucket_id={}'.format(settings.DATA_REG_SERVICE_SERVER_URL,
                                                                                         token, ds_uuid)
     auth_header_str = 'Basic {}'.format(settings.DATA_REG_API_KEY)
     response = requests.get(url,
@@ -58,7 +58,7 @@ def register(request):
 
         # create iRODS resource first before registering the path
         url = '{}registration/create_resource?provider=globus&bucket_id={}&subjectid={}'.format(
-            settings.SERVICE_SERVER_URL, ds_uuid, uid)
+            settings.DATA_REG_SERVICE_SERVER_URL, ds_uuid, uid)
         auth_header_str = 'Basic {}'.format(settings.DATA_REG_API_KEY)
 
         response = requests.get(url, headers={'Authorization': auth_header_str}, verify=False)
@@ -75,7 +75,7 @@ def register(request):
         }
 
         # list file/dir entries for a given globus storage bucket id
-        url = '{}registration/register_paths'.format(settings.SERVICE_SERVER_URL)
+        url = '{}registration/register_paths'.format(settings.DATA_REG_SERVICE_SERVER_URL)
         response = requests.post(url, data=json.dumps(p_data), headers={'Authorization': auth_header_str}, verify=False)
         if response.status_code != status.HTTP_200_OK:
             # request fails

--- a/hydroshare/local_settings.py
+++ b/hydroshare/local_settings.py
@@ -171,8 +171,9 @@ HS_IRODS_LOCAL_ZONE_DEF_RES = 'hydroshareLocalResc'
 HS_WWW_IRODS_ZONE = ''
 HS_USER_IRODS_ZONE = 'hydroshareuserZone'
 
-SERVICE_SERVER_URL = ''
+OAUTH_SERVICE_SERVER_URL = ''
 OAUTH_APP_KEY = ''
+DATA_REG_SERVICE_SERVER_URL = ''
 DATA_REG_API_KEY = ''
 
 # Email configuration

--- a/irods_browser_app/views.py
+++ b/irods_browser_app/views.py
@@ -64,8 +64,8 @@ def get_openid_token(request):
     url = 'token?uid={}&provider=globus&scope=openid%20email%20profile'.format(uid)
     # note that trailing slash should not be added to return_to url
     # return_url = '&return_to={}://{}/irods/openid_return'.format(request.scheme, request.get_host())
-    # req_url = '{}{}{}'.format(settings.SERVICE_SERVER_URL, url, return_url)
-    req_url = '{}{}'.format(settings.SERVICE_SERVER_URL, url)
+    # req_url = '{}{}{}'.format(settings.OAUTH_SERVICE_SERVER_URL, url, return_url)
+    req_url = '{}{}'.format(settings.OAUTH_SERVICE_SERVER_URL, url)
     auth_header_str = 'Basic {}'.format(settings.OAUTH_APP_KEY)
     response = requests.get(req_url,
                             headers={'Authorization': auth_header_str},

--- a/theme/backends/apikey_auth.py
+++ b/theme/backends/apikey_auth.py
@@ -26,7 +26,7 @@ class APIKeyAuthentication(authentication.BaseAuthentication):
             except User.DoesNotExist:
                 raise AuthenticationFailed('User does not exist')
 
-            url = '{}apikey/verify'.format(settings.SERVICE_SERVER_URL)
+            url = '{}apikey/verify'.format(settings.OAUTH_SERVICE_SERVER_URL)
             auth_header_str = 'Basic {}'.format(settings.OAUTH_APP_KEY)
             response = requests.get(url, headers={'Authorization': auth_header_str},
                                     params={'username': username,

--- a/theme/backends/globus.py
+++ b/theme/backends/globus.py
@@ -39,7 +39,7 @@ class GlobusOAuth2:
                                       superuser=False, active=True)
                 # create corresponding iRODS account with same username via OAuth if not exist already
                 url = '{}registration/create_account?username={}&zone={}&auth_name={}'.format(
-                    settings.SERVICE_SERVER_URL, username, settings.IRODS_ZONE, uid)
+                    settings.DATA_REG_SERVICE_SERVER_URL, username, settings.IRODS_ZONE, uid)
                 response = requests.get(url,
                                         headers={'Authorization': auth_header_str},
                                         verify=False)
@@ -51,7 +51,7 @@ class GlobusOAuth2:
 
             hashed_token = hashlib.sha256(access_token).hexdigest()[0:50]
             url = '{}registration/add_user_oids?username={}&subjectid={}&sessionid={}'.format(
-                settings.SERVICE_SERVER_URL,
+                settings.DATA_REG_SERVICE_SERVER_URL,
                 username, uid, hashed_token)
             response = requests.get(url, headers={'Authorization': auth_header_str}, verify=False)
             if response.status_code !=status.HTTP_200_OK:

--- a/theme/views.py
+++ b/theme/views.py
@@ -431,7 +431,7 @@ def send_verification_mail_for_password_reset(request, user):
 def oauth_request(request):
     # note that trailing slash should not be added to return_to url
     return_url = '&return_to={}://{}/oauth_return'.format(request.scheme, request.get_host())
-    url = '{}authorize?provider=globus&scope=openid%20email%20profile{}'.format(settings.SERVICE_SERVER_URL, return_url)
+    url = '{}authorize?provider=globus&scope=openid%20email%20profile{}'.format(settings.OAUTH_SERVICE_SERVER_URL, return_url)
     auth_header_str = 'Basic {}'.format(settings.OAUTH_APP_KEY)
     response = requests.get(url,
                             headers={'Authorization': auth_header_str},
@@ -487,7 +487,7 @@ def oauth_return(request):
 @login_required
 def generate_token(request, uid):
     lbl = request.POST.get('label', '')
-    url = '{}apikey/{}/new'.format(settings.SERVICE_SERVER_URL, uid)
+    url = '{}apikey/{}/new'.format(settings.OAUTH_SERVICE_SERVER_URL, uid)
     auth_header_str = 'Basic {}'.format(settings.OAUTH_APP_KEY)
     response = requests.get(url, params={'label': lbl}, headers={'Authorization': auth_header_str})
     if response.status_code != status.HTTP_200_OK:
@@ -503,7 +503,7 @@ def generate_token(request, uid):
 
 @login_required
 def get_all_tokens(request, uid):
-    url = '{}apikey/{}'.format(settings.SERVICE_SERVER_URL, uid)
+    url = '{}apikey/{}'.format(settings.OAUTH_SERVICE_SERVER_URL, uid)
     auth_header_str = 'Basic {}'.format(settings.OAUTH_APP_KEY)
     response = requests.get(url, headers={'Authorization': auth_header_str})
     if response.status_code != status.HTTP_200_OK:
@@ -526,7 +526,7 @@ def get_all_tokens(request, uid):
 
 @login_required
 def delete_all_tokens(request, uid):
-    url = '{}apikey/{}'.format(settings.SERVICE_SERVER_URL, uid)
+    url = '{}apikey/{}'.format(settings.OAUTH_SERVICE_SERVER_URL, uid)
     auth_header_str = 'Basic {}'.format(settings.OAUTH_APP_KEY)
     tokens_list_str = request.POST.get('tokens', '')
 
@@ -571,7 +571,7 @@ def retrieve_globus_buckets(request):
         return HttpResponseBadRequest(content='user subject id is empty')
 
     url = 'token?uid={}&provider=globus&scope=urn:globus:auth:scope:transfer.api.globus.org:all'.format(uid)
-    req_url = '{}{}{}'.format(settings.SERVICE_SERVER_URL, url, return_url)
+    req_url = '{}{}{}'.format(settings.OAUTH_SERVICE_SERVER_URL, url, return_url)
 
     auth_header_str = 'Basic {}'.format(settings.OAUTH_APP_KEY)
     response = requests.get(req_url,
@@ -602,7 +602,7 @@ def globus_data_auth_return(request):
         return HttpResponseBadRequest('Bad request - no valid access_token is provided')
 
     # get avaiable endpoints for a given globus user
-    url = '{}registration/get_buckets?provider=globus&token={}'.format(settings.SERVICE_SERVER_URL, token)
+    url = '{}registration/get_buckets?provider=globus&token={}'.format(settings.DATA_REG_SERVICE_SERVER_URL, token)
     auth_header_str = 'Basic {}'.format(settings.DATA_REG_API_KEY)
     response = requests.get(url,
                             headers={'Authorization': auth_header_str},


### PR DESCRIPTION
This PR is to separate the service server urls for oauth service and data registration and account creation service since they could run on different servers, e.g., oauth service still runs on test.commonsshare.org while account creation and data registration service runs on AWS iCAT VM for helium.commonsshare.org. 